### PR TITLE
CompatHelper: bump compat for Roots to 2, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 WilliamsonTransforms = "48feb556-9bdd-43a2-8e10-96100ec25e22"
 
 [compat]
-julia = "1.6"
 Cubature = "1.5"
 Distributions = "0.25"
 ForwardDiff = "0.10"
@@ -28,12 +27,13 @@ LogExpFunctions = "0.3"
 PolyLog = "1.5"
 QuadGK = "2"
 Random = "1.5"
-Roots = "1"
+Roots = "1, 2"
 SpecialFunctions = "2"
 Statistics = "1.5"
 StatsBase = "0.33"
 StatsFuns = "0.9"
 WilliamsonTransforms = "0.1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This pull request changes the compat entry for the `Roots` package from `1` to `1, 2`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.